### PR TITLE
ViewPager with pageMargin over-scroll not work when scrolling forward and backward

### DIFF
--- a/app/src/main/java/me/everything/overscrolldemo/view/ViewPagerDemoFragment.java
+++ b/app/src/main/java/me/everything/overscrolldemo/view/ViewPagerDemoFragment.java
@@ -39,6 +39,7 @@ public class ViewPagerDemoFragment extends Fragment {
     }
 
     private void initHorizontalViewPager(List<DemoItem> items, ViewPager viewPager) {
+        viewPager.setPageMargin(20);
 
         ViewPagerAdapter adapter = new ViewPagerAdapter(items);
         viewPager.setAdapter(adapter);

--- a/liboverscroll/src/main/java/me/everything/android/ui/overscroll/adapters/ViewPagerOverScrollDecorAdapter.java
+++ b/liboverscroll/src/main/java/me/everything/android/ui/overscroll/adapters/ViewPagerOverScrollDecorAdapter.java
@@ -16,6 +16,8 @@ import me.everything.android.ui.overscroll.HorizontalOverScrollBounceEffectDecor
  */
 public class ViewPagerOverScrollDecorAdapter implements IOverScrollDecoratorAdapter, ViewPager.OnPageChangeListener {
 
+    private static final float APPROXIMATELY_EQUAL_DELTA = 0.001f;
+
     protected final ViewPager mViewPager;
 
     protected int mLastPagerPosition = 0;
@@ -37,31 +39,31 @@ public class ViewPagerOverScrollDecorAdapter implements IOverScrollDecoratorAdap
 
     @Override
     public boolean isInAbsoluteStart() {
-
-        return mLastPagerPosition == 0 &&
-                mLastPagerScrollOffset == 0f;
+        return mLastPagerPosition == 0 && isApproximatelyEquals(mLastPagerScrollOffset, 0f);
     }
 
     @Override
     public boolean isInAbsoluteEnd() {
-
-        return mLastPagerPosition == mViewPager.getAdapter().getCount()-1 &&
-                mLastPagerScrollOffset == 0f;
+        return mLastPagerPosition == mViewPager.getAdapter().getCount() - 1 &&
+                (isApproximatelyEquals(mLastPagerScrollOffset, 0f) || isApproximatelyEquals(mLastPagerScrollOffset, 1f));
     }
 
     @Override
     public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-        mLastPagerPosition = position;
         mLastPagerScrollOffset = positionOffset;
     }
 
     @Override
     public void onPageSelected(int position) {
-
+        mLastPagerPosition = position;
     }
 
     @Override
     public void onPageScrollStateChanged(int state) {
 
+    }
+
+    private static boolean isApproximatelyEquals(float first, float second) {
+        return Math.abs(second - first) < APPROXIMATELY_EQUAL_DELTA;
     }
 }


### PR DESCRIPTION
I face the same issue as the one mentioned here #35 

The Over scroll effect does not work properly when I use a `ViewPager` with `setPageMargin` to a non-zero value. I found out the problem comes from the `ViewPager` because it doesn't give us the correct `positionOffset` in `onPageScrolled`. The offset is very small nearly to 0 but not 0, the same for 1.

So a way to fix this is to compare the float `mLastPagerScrollOffset` approximately and it works