### PR TITLE
Fix counter-orientation-direction operations on some devices

### DIFF
--- a/liboverscroll/src/main/java/me/everything/android/ui/overscroll/HorizontalOverScrollBounceEffectDecorator.java
+++ b/liboverscroll/src/main/java/me/everything/android/ui/overscroll/HorizontalOverScrollBounceEffectDecorator.java
@@ -23,6 +23,9 @@ public class HorizontalOverScrollBounceEffectDecorator extends OverScrollBounceE
             // Allow for counter-orientation-direction operations (e.g. item swiping) to run fluently.
             final float dy = event.getY(0) - event.getHistoricalY(0, 0);
             final float dx = event.getX(0) - event.getHistoricalX(0, 0);
+            if (dx == 0 && dy == 0) {
+                return false;
+            }
             if (Math.abs(dx) < Math.abs(dy)) {
                 return false;
             }

--- a/liboverscroll/src/main/java/me/everything/android/ui/overscroll/VerticalOverScrollBounceEffectDecorator.java
+++ b/liboverscroll/src/main/java/me/everything/android/ui/overscroll/VerticalOverScrollBounceEffectDecorator.java
@@ -23,6 +23,9 @@ public class VerticalOverScrollBounceEffectDecorator extends OverScrollBounceEff
             // Allow for counter-orientation-direction operations (e.g. item swiping) to run fluently.
             final float dy = event.getY(0) - event.getHistoricalY(0, 0);
             final float dx = event.getX(0) - event.getHistoricalX(0, 0);
+            if (dx == 0 && dy == 0) {
+                return false;
+            }
             if (Math.abs(dx) > Math.abs(dy)) {
                 return false;
             }


### PR DESCRIPTION
I have noticed that on some devices the counter-orientation-direction operations does not work.
After short debugging I have noticed that `dx` and `dy` are equal to 0 at the beginning of dragging on these devices and therefore it's not triggering the `Math.abs(dx) > Math.abs(dy)` condition. In order to fix this issue I have added zero check on `dx` and `dy`.

Tested on Samsung Galaxy S8, Samsung Galaxy S20+, Samsung Galaxy A6, Sony Xperia Z2, Huawei P40 Lite and Google Pixel 4. Problem occured only on last two of them. Now it works good on all these devices.